### PR TITLE
Add Trigger Campaign Functionality 

### DIFF
--- a/fixture/vcr_cassettes/trigger_campaign/pass.json
+++ b/fixture/vcr_cassettes/trigger_campaign/pass.json
@@ -1,0 +1,31 @@
+[
+  {
+    "request": {
+      "body": "{\"data\":{\"title\":\"Campaign Test\"}}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": {
+        "basic_auth": "***"
+      },
+      "request_body": "",
+      "url": "https://api.customer.io/v1/api/campaigns/7/triggers"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"id\":47}",
+      "headers": {
+        "Cache-Control": "no-cache, no-store, must-revalidate, max-age=0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Status": "200 OK",
+        "Date": "Sat, 03 Jun 2019 09:00:01 GMT",
+        "Content-Length": "3",
+        "Via": "1.1 google",
+        "Alt-Svc": "clear"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/customerio.ex
+++ b/lib/customerio.ex
@@ -40,7 +40,7 @@ defmodule Customerio do
           opts :: [key: value]
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def identify(id, data_map, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :put,
       "customers/#{URI.encode(id |> to_string)}",
       data_map,
@@ -105,7 +105,7 @@ defmodule Customerio do
           opts :: [key: value]
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def delete(id, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :delete,
       "customers/#{URI.encode(id |> to_string)}",
       %{},
@@ -173,7 +173,7 @@ defmodule Customerio do
           opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def track(id, name, data_map, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :post,
       "customers/#{URI.encode(id |> to_string)}/events",
       %{name: name, data: data_map},
@@ -244,7 +244,7 @@ defmodule Customerio do
           opts :: [key: value]
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def anonymous_track(name, data_map, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :post,
       "events",
       %{name: name, data: data_map},
@@ -315,7 +315,7 @@ defmodule Customerio do
           opts :: [key: value]
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def track_page_view(id, page_name, data_map, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :post,
       "customers/#{URI.encode(id |> to_string)}/events",
       %{name: page_name, type: "page", data: data_map},
@@ -399,7 +399,7 @@ defmodule Customerio do
           opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def add_device(id, device_id, platfrom, data_map \\ %{}, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :put,
       "customers/#{URI.encode(id |> to_string)}/devices",
       %{device: Map.merge(%{id: device_id, platform: platfrom}, data_map)},
@@ -476,7 +476,7 @@ defmodule Customerio do
           opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def delete_device(id, device_id, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :delete,
       "customers/#{URI.encode(id |> to_string)}/devices/#{URI.encode(device_id |> to_string)}",
       %{},
@@ -547,7 +547,7 @@ defmodule Customerio do
           opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def suppress(id, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :post,
       "customers/#{URI.encode(id |> to_string)}/suppress",
       %{},
@@ -614,7 +614,7 @@ defmodule Customerio do
           opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def unsuppress(id, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :post,
       "customers/#{URI.encode(id |> to_string)}/unsuppress",
       %{},
@@ -689,7 +689,7 @@ defmodule Customerio do
           opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def add_to_segment(id, ids, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :post,
       "segments/#{URI.encode(id |> to_string)}/add_customers",
       %{ids: ids},
@@ -760,7 +760,7 @@ defmodule Customerio do
           opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def remove_from_segment(id, ids, opts \\ []) do
-    send_request(
+    send_behavioral_request(
       :post,
       "segments/#{URI.encode(id |> to_string)}/remove_customers",
       %{ids: ids},
@@ -800,5 +800,9 @@ defmodule Customerio do
   else
     {:ok, result} -> result
     {:error, e} -> raise e
+  end
+
+  def trigger_campaign(id, data \\ []) do
+    send_api_request(:post, "/campaigns/#{URI.encode(id |> to_string)}/triggers", data)
   end
 end

--- a/lib/customerio.ex
+++ b/lib/customerio.ex
@@ -818,7 +818,7 @@ defmodule Customerio do
   ```
   """
 
-  def trigger_campaign(id, data \\ []) do
+  def trigger_campaign(id, data_map, opts \\ []) do
     send_api_request(:post, "/campaigns/#{URI.encode(id |> to_string)}/triggers", data)
   end
 end

--- a/lib/customerio.ex
+++ b/lib/customerio.ex
@@ -817,8 +817,12 @@ defmodule Customerio do
   iex> Customerio.trigger_campaign(1, %{data: %{title: "hello"}})
   ```
   """
-
+  @spec trigger_campaign(
+    id :: value,
+    data_map :: map(),
+    opts :: Keyword.t()
+  ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def trigger_campaign(id, data_map, opts \\ []) do
-    send_api_request(:post, "/campaigns/#{URI.encode(id |> to_string)}/triggers", data)
+    send_api_request(:post, "/campaigns/#{URI.encode(id |> to_string)}/triggers", data_map, opts)
   end
 end

--- a/lib/customerio.ex
+++ b/lib/customerio.ex
@@ -802,6 +802,22 @@ defmodule Customerio do
     {:error, e} -> raise e
   end
 
+  @doc """
+  Trigger a campaign execution.
+
+  ## Params
+
+    * `id` - the unique identifier of the campaign.
+
+    * `data` - data to be included in the campaign.
+
+  ## Example
+
+  ```elixir
+  iex> Customerio.trigger_campaign(1, %{data: %{title: "hello"}})
+  ```
+  """
+
   def trigger_campaign(id, data \\ []) do
     send_api_request(:post, "/campaigns/#{URI.encode(id |> to_string)}/triggers", data)
   end

--- a/lib/customerio/util.ex
+++ b/lib/customerio/util.ex
@@ -50,17 +50,13 @@ defmodule Customerio.Util do
     send_request(method, @api_base_route <> route, data_map, opts)
   end
 
-  @doc """
-  This method sends requests to `customer.io` API endpoints, with
-  defined method, route, body and HTTPoison options.
-  """
   @spec send_request(
           method :: method,
           route :: String.t(),
           data_map :: map(),
           opts :: Keyword.t()
         ) :: {:ok, String.t()} | {:error, Customerio.Error.t()}
-  defp send_request(method, route, data_map, opts \\ []) do
+  defp send_request(method, route, data_map, opts) do
     :hackney.request(
       method,
       route,

--- a/lib/customerio/util.ex
+++ b/lib/customerio/util.ex
@@ -2,7 +2,9 @@ defmodule Customerio.Util do
   @moduledoc false
   @type value :: number | String.t() | atom()
 
-  @base_route "https://track.customer.io/api/v1/"
+  @behavioral_base_route "https://track.customer.io/api/v1/"
+
+  @api_base_route "https://api.customer.io/v1/api"
 
   defp get_username, do: Application.get_env(:customerio, :site_id)
   defp get_password, do: Application.get_env(:customerio, :api_key)
@@ -20,6 +22,14 @@ defmodule Customerio.Util do
   """
   @type method :: :get | :post | :delete | :put | :patch
 
+  def send_behavioral_request(method, route, data_map, opts \\ []) do
+    send_request(method, @behavioral_base_route <> route, data_map, opts)
+  end
+
+  def send_api_request(method, route, data_map, opts \\ []) do
+    send_request(method, @api_base_route <> route, data_map, opts)
+  end
+
   @doc """
   This method sends requests to `customer.io` API endpoint, with
   defined method, route, body and HTTPoison options.
@@ -33,7 +43,7 @@ defmodule Customerio.Util do
   def send_request(method, route, data_map, opts \\ []) do
     :hackney.request(
       method,
-      @base_route <> route,
+      route,
       put_headers(),
       data_map |> Jason.encode!(),
       with_auth(opts)

--- a/lib/customerio/util.ex
+++ b/lib/customerio/util.ex
@@ -22,16 +22,36 @@ defmodule Customerio.Util do
   """
   @type method :: :get | :post | :delete | :put | :patch
 
+  @doc """
+  This method sends requests to `customer.io` Behavioral API endpoint, with
+  defined method, route, body and HTTPoison options.
+  """
+  @spec send_behavioral_request(
+          method :: method,
+          route :: String.t(),
+          data_map :: map(),
+          opts :: Keyword.t()
+        ) :: {:ok, String.t()} | {:error, Customerio.Error.t()}
   def send_behavioral_request(method, route, data_map, opts \\ []) do
     send_request(method, @behavioral_base_route <> route, data_map, opts)
   end
 
+  @doc """
+  This method sends requests to `customer.io` API endpoint, with
+  defined method, route, body and HTTPoison options.
+  """
+  @spec send_api_request(
+          method :: method,
+          route :: String.t(),
+          data_map :: map(),
+          opts :: Keyword.t()
+        ) :: {:ok, String.t()} | {:error, Customerio.Error.t()}
   def send_api_request(method, route, data_map, opts \\ []) do
     send_request(method, @api_base_route <> route, data_map, opts)
   end
 
   @doc """
-  This method sends requests to `customer.io` API endpoint, with
+  This method sends requests to `customer.io` API endpoints, with
   defined method, route, body and HTTPoison options.
   """
   @spec send_request(
@@ -40,7 +60,7 @@ defmodule Customerio.Util do
           data_map :: map(),
           opts :: Keyword.t()
         ) :: {:ok, String.t()} | {:error, Customerio.Error.t()}
-  def send_request(method, route, data_map, opts \\ []) do
+  defp send_request(method, route, data_map, opts \\ []) do
     :hackney.request(
       method,
       route,

--- a/test/customerio/trigger_campain_test.exs
+++ b/test/customerio/trigger_campain_test.exs
@@ -1,0 +1,13 @@
+defmodule Customerio.TriggerCampaignTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  describe "Customerio::trigger_campaign" do
+    test "Successful campaign trigger" do
+      use_cassette "trigger_campaign/pass" do
+        assert {:ok, result} = Customerio.trigger_campaign(7, %{data: %{title: "Campaign Test"}})
+        assert "{\"id\":47}" == result
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the API trigger for campaigns as stated here: [https://customer.io/docs/api/#apibroadcast_trigger](https://customer.io/docs/api/#apibroadcast_trigger)