### PR TITLE
Fix formatting on Getting Started doc

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -22,7 +22,8 @@ $ mix deps.get
 
 The **JavaScript** snippet tracks basic behavior for you just by copy/pasting it onto your site. In many cases, using the **JavaScript** snippet will be easier to integrate with your app, but there are several reasons why sending events from your backend is useful:
 
-You’re not planning on triggering emails based on how customers interact with your website (e.g. users who haven’t visited the site in X days)
-You’re using the javascript snippet, but have a few events you’d like to send from your backend system. They will work well together!
-You’d rather not have another javascript snippet slowing down your frontend. Our snippet is asynchronous (doesn’t affect initial page load) and very small, but we understand.
+- You’re not planning on triggering emails based on how customers interact with your website (e.g. users who haven’t visited the site in X days)
+- You’re using the JavaScript snippet, but have a few events you’d like to send from your backend system. They will work well together!
+- You’d rather not have another JavaScript snippet slowing down your frontend, although the Customer.io snippet is asynchronous (doesn’t affect initial page load) and very small.
+
 In the end, the decision on whether or not to send events from your backend or the **JavaScript** snippet should be based on what works best for you. You’ll be able to integrate fully with **Customer.io** with either approach.

--- a/lib/customerio.ex
+++ b/lib/customerio.ex
@@ -23,7 +23,7 @@ defmodule Customerio do
 
     * `data_map` - custom attributes to define the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -36,8 +36,8 @@ defmodule Customerio do
   """
   @spec identify(
           id :: value,
-          data_map :: %{key: value},
-          opts :: [key: value]
+          data_map :: %{optional(atom) => value},
+          opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def identify(id, data_map, opts \\ []) do
     send_behavioral_request(
@@ -59,7 +59,7 @@ defmodule Customerio do
 
     * `data_map` - custom attributes to define the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -72,7 +72,7 @@ defmodule Customerio do
   """
   @spec identify!(
           id :: value,
-          data_map :: %{key: value},
+          data_map :: %{optional(atom) => value},
           opts :: Keyword.t()
         ) :: result | no_return()
   def identify!(id, data_map, opts \\ []) do
@@ -89,7 +89,7 @@ defmodule Customerio do
 
     * `id` - the unique identifier for the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -102,7 +102,7 @@ defmodule Customerio do
   """
   @spec delete(
           id :: value,
-          opts :: [key: value]
+          opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def delete(id, opts \\ []) do
     send_behavioral_request(
@@ -122,7 +122,7 @@ defmodule Customerio do
 
     * `id` - the unique identifier for the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -155,7 +155,7 @@ defmodule Customerio do
 
     * `data_map` - custom attributes to define the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -169,7 +169,7 @@ defmodule Customerio do
   @spec track(
           id :: value,
           name :: value,
-          data_map :: %{key: value},
+          data_map :: %{optional(atom) => value},
           opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def track(id, name, data_map, opts \\ []) do
@@ -194,7 +194,7 @@ defmodule Customerio do
 
     * `data_map` - custom attributes to define the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -208,8 +208,8 @@ defmodule Customerio do
   @spec track!(
           id :: value,
           name :: value,
-          data_map :: %{key: value},
-          opts :: [key: value]
+          data_map :: %{optional(atom) => value},
+          opts :: Keyword.t()
         ) :: result | no_return()
   def track!(id, name, data_map, opts \\ []) do
     case track(id, name, data_map, opts) do
@@ -227,7 +227,7 @@ defmodule Customerio do
 
     * `data_map` - custom attributes to define the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -240,8 +240,8 @@ defmodule Customerio do
   """
   @spec anonymous_track(
           name :: value,
-          data_map :: %{key: value},
-          opts :: [key: value]
+          data_map :: %{optional(atom) => value},
+          opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def anonymous_track(name, data_map, opts \\ []) do
     send_behavioral_request(
@@ -263,7 +263,7 @@ defmodule Customerio do
 
     * `data_map` - custom attributes to define the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -276,8 +276,8 @@ defmodule Customerio do
   """
   @spec anonymous_track!(
           name :: value,
-          data_map :: %{key: value},
-          opts :: [key: value]
+          data_map :: %{optional(atom) => value},
+          opts :: Keyword.t()
         ) :: result | no_return()
   def anonymous_track!(name, data_map, opts \\ []) do
     case anonymous_track(name, data_map, opts) do
@@ -297,7 +297,7 @@ defmodule Customerio do
 
     * `data_map` - custom attributes to define the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -311,8 +311,8 @@ defmodule Customerio do
   @spec track_page_view(
           id :: value,
           page_name :: String.t(),
-          data_map :: %{key: value},
-          opts :: [key: value]
+          data_map :: %{optional(atom) => value},
+          opts :: Keyword.t()
         ) :: {:ok, result} | {:error, Customerio.Error.t()}
   def track_page_view(id, page_name, data_map, opts \\ []) do
     send_behavioral_request(
@@ -336,7 +336,7 @@ defmodule Customerio do
 
     * `data_map` - custom attributes to define the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -350,8 +350,8 @@ defmodule Customerio do
   @spec track_page_view!(
           id :: value,
           page_name :: value,
-          data_map :: %{key: value},
-          opts :: [key: value]
+          data_map :: %{optional(atom) => value},
+          opts :: Keyword.t()
         ) :: result | no_return()
   def track_page_view!(id, page_name, data_map, opts \\ []) do
     case track_page_view(id, page_name, data_map, opts) do
@@ -380,7 +380,7 @@ defmodule Customerio do
       * `last_used` - UNIX timestamp representing the last used time for the device.
         If this is not included we default to the time of the device identify.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -425,7 +425,7 @@ defmodule Customerio do
       * `last_used` - UNIX timestamp representing the last used time for the device.
         If this is not included we default to the time of the device identify.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -459,7 +459,7 @@ defmodule Customerio do
 
     * `device_id` - the unique token for the user device.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -495,7 +495,7 @@ defmodule Customerio do
 
     * `device_id` - the unique token for the user device.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -531,7 +531,7 @@ defmodule Customerio do
 
     * `id` - the unique identifier for the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -566,7 +566,7 @@ defmodule Customerio do
 
     * `id` - the unique identifier for the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -598,7 +598,7 @@ defmodule Customerio do
 
     * `id` - the unique identifier for the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -634,7 +634,7 @@ defmodule Customerio do
 
     * `id` - the unique identifier for the customer.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -672,7 +672,7 @@ defmodule Customerio do
 
     * `ids` - a list of customer ids to add to the segment.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -711,7 +711,7 @@ defmodule Customerio do
 
     * `ids` - a list of customer ids to add to the segment.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -743,7 +743,7 @@ defmodule Customerio do
 
     * `ids` - a list of customer ids to add to the segment.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 
@@ -779,7 +779,7 @@ defmodule Customerio do
 
     * `ids` - a list of customer ids to add to the segment.
 
-    * `opts` - HTTPoison options.
+    * `opts` - Hackney options.
 
   ## Example
 

--- a/lib/customerio/util.ex
+++ b/lib/customerio/util.ex
@@ -24,7 +24,7 @@ defmodule Customerio.Util do
 
   @doc """
   This method sends requests to `customer.io` Behavioral API endpoint, with
-  defined method, route, body and HTTPoison options.
+  defined method, route, body and Hackney options.
   """
   @spec send_behavioral_request(
           method :: method,
@@ -38,7 +38,7 @@ defmodule Customerio.Util do
 
   @doc """
   This method sends requests to `customer.io` API endpoint, with
-  defined method, route, body and HTTPoison options.
+  defined method, route, body and Hackney options.
   """
   @spec send_api_request(
           method :: method,


### PR DESCRIPTION
| Before | After |
|-------|-------|
| <img width="877" alt="before" src="https://user-images.githubusercontent.com/803680/152032362-ac878431-64f8-4394-a080-4c840067e41f.png"> |  <img width="906" alt="after" src="https://user-images.githubusercontent.com/803680/152032596-0c7e8ff4-866a-4508-a0f0-fa0a4ea7b733.png"> |

(Note, of course, that the "after" image came from the latest version of ExDoc—I had to upgrade to 0.28 to run it under Elixir 1.13.)